### PR TITLE
Feature: Add user with existing main user group

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -94,8 +94,10 @@ define identity::user (
   validate_bool($manage_group)
 
   # Check if gid is set when manage_group is false
-  if (!$manage_group and !$gid) {
-    fail('If group is not managed, the gid has to be set')
+  unless $manage_group {
+    unless $gid {
+      fail('If group is not managed, the gid has to be set')
+    }
   }
 
   # Variable collection

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -183,7 +183,7 @@ define identity::user (
           source  => $dotfiles_source,
           recurse => $home_perms_recursive,
           owner   => $username,
-          group   => $_gid,
+          group   => $_group,
           mode    => $home_perms,
         }
       }

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -4,11 +4,11 @@ describe 'identity::user', :type => :define do
   let(:title) { 'testuser'}
 
   it { should contain_user('testuser') }
-  it { should contain_group('testuser') }
   it { should contain_class('identity') }
 
   context 'with ensure => absent' do
     let(:params) { { 'ensure' => 'absent' } }
+    it { should contain_group('testuser') }
     it { should contain_user('testuser').with_ensure('absent') }
     it { should contain_group('testuser').with_ensure('absent') }
     context 'with ensure => absent and manage_home => true' do
@@ -19,11 +19,13 @@ describe 'identity::user', :type => :define do
   # ignore_uid_gid functionality
   context 'with ignore_uid_gid => false and uid define' do
     let(:params) { { 'ignore_uid_gid' => false, 'uid' => 1000 } }
+    it { should contain_group('testuser') }
     it { should contain_user('testuser').with_uid(1000) }
     it { should contain_group('testuser').with_gid(1000) }
   end
   context 'with ignore_uid_gid => true and uid defined' do
     let(:params) { { 'ignore_uid_gid' => true, 'uid' => 1000 } }
+    it { should contain_group('testuser') }
     it { should contain_user('testuser').with_uid(nil) }
     it { should contain_group('testuser').with_gid(nil) }
   end
@@ -31,17 +33,31 @@ describe 'identity::user', :type => :define do
   # manage_dotfiles and manage_home
   context 'with manage_dotfiles => true' do
     let(:params) { { 'manage_dotfiles' => true } }
+    it { should contain_group('testuser') }
     it { should contain_file('/home/testuser').with_ensure('directory') }
     it { should contain_file('/home/testuser').with_mode('0755') }
   end
   context 'with manage_dotfiles => true and manage_home => false' do
     let(:params) { { 'manage_dotfiles' => true, 'manage_home' => false } }
+    it { should contain_group('testuser') }
     it { should_not contain_file('/home/testuser') }
   end
   context 'with home_perms => 0700' do
     let(:params) { { 'home_perms' => '0700' } }
+    it { should contain_group('testuser') }
     it { should contain_file('/home/testuser').with_ensure('directory') }
     it { should contain_file('/home/testuser').with_mode('0700') }
+  end
+
+  # manage_group
+  context 'with manage_group => false' do
+    let(:params) { { 'manage_group' => false, 'gid' => 'test' } }
+    let(:pre_condition) do
+      'identity::group {"test":
+        gid => "3210",
+      }'
+    end
+    it { should contain_group('test') }
   end
 
   # ssh keys
@@ -49,8 +65,10 @@ describe 'identity::user', :type => :define do
     let(:params) {{
       :ssh_keys => { 'main' => { 'key' => 'thisisnotakey' } }
     }}
+    it { should contain_group('testuser') }
     it { is_expected.to have_ssh_authorized_key_resource_count(1) }
     it { is_expected.to contain_ssh_authorized_key('main') }
   end
+  
 
 end

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -58,6 +58,7 @@ describe 'identity::user', :type => :define do
       }'
     end
     it { should contain_group('test') }
+    it { should_not contain_group('testuser') }
   end
 
   # ssh keys

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -53,7 +53,7 @@ describe 'identity::user', :type => :define do
   context 'with manage_group => false' do
     let(:params) { { 'manage_group' => false, 'gid' => 'test' } }
     let(:pre_condition) do
-      'identity::group {"test":
+      'group { "test":
         gid => "3210",
       }'
     end
@@ -70,6 +70,5 @@ describe 'identity::user', :type => :define do
     it { is_expected.to have_ssh_authorized_key_resource_count(1) }
     it { is_expected.to contain_ssh_authorized_key('main') }
   end
-  
 
 end


### PR DESCRIPTION
I added a parameter so the main user group is not unconditionally
created and a different one can be used.
