### PR TITLE
WIP: Change Default User permissions

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -40,7 +40,7 @@
 #   Default: false. Manage home folder permissions recursively.
 #
 # [*home_perms*]
-#   Default: 0755. Home folder permissions
+#   Default: 0750. Home folder permissions
 #
 # [*system*]
 #   Default: false. See https://docs.puppetlabs.com/references/latest/type.html#user-attribute-system
@@ -76,7 +76,7 @@ define identity::user (
   $manage_home          = true,
   $home                 = undef,
   $home_perms_recursive = false,
-  $home_perms           = '0755',
+  $home_perms           = '0750',
   $system               = false,
   $shell                = '/bin/bash',
   $ignore_uid_gid       = false,

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -32,7 +32,7 @@ describe 'identity::user', :type => :define do
     let(:params) { { 'manage_dotfiles' => true } }
     it { should contain_group('testuser') }
     it { should contain_file('/home/testuser').with_ensure('directory') }
-    it { should contain_file('/home/testuser').with_mode('0755') }
+    it { should contain_file('/home/testuser').with_mode('0750') }
   end
   context 'with manage_dotfiles => true and manage_home => false' do
     let(:params) { { 'manage_dotfiles' => true, 'manage_home' => false } }


### PR DESCRIPTION
As stated in #7 the default permissions for the home directory are to
relaxed. This will change all home directories so they are not world
readable anymore. If the old behaviour is still required one can set
that in identity::duser_defaults.
