### PR TITLE
Enable configuring a user with a non-standard primary group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
   include:
     fast_finish: true
   include:
-  - rvm: 2.1.9
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,21 @@
 # CHANGELOG
 
 ## Unreleased
+
+## [5.0.0] - 2019-08-23
+
+### Removed
+* Puppet 4 testing/compatibility
+
+### Fixed
+* Disallow specifying a non-numerical primary group when user's primary group is managed
+* Correctly set user's home directory group to the provided gid when user's primary group is not managed
+
+### Note
+* For puppet 5 this change is backwards compatible
+
+## [4.0.1] - 2019-03-07
+
 ### Added
 
 * Option to set group membership behaviour

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -238,9 +238,9 @@ define identity::user (
           default => undef,
         }
         if $manage_group {
-          $_group = $_gid
-        } else {
           $_group = $username
+        } else {
+          $_group = $gid
         }
         file { $home_dir:
           ensure  => directory,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -94,8 +94,12 @@ define identity::user (
 
   # Input validation
 
-  # Check if gid is set when manage_group is false
-  unless $manage_group {
+  # Validate that the combination of manage_group and gid works
+  if $manage_group {
+    if $gid =~ String {
+      fail('Cannot specify $gid as string when $manage_group=true')
+    }
+  } else {
     unless $gid {
       fail('If group is not managed, the gid has to be set')
     }


### PR DESCRIPTION
Address inconsistent combinations of `$manage_group` and `$gid`:
* Always set a user's home directory group to `$gid` when `$manage_group` is false, as that's the only sensible option if we do not manage the user's primary group
* Disallow specifying a user's primary group as a group name when `$manage_group` is true, as a Group puppet resource can only be created with a numerical gid.